### PR TITLE
時空間IDに対するホップアップの実装/コピー機能の実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,8 +32,14 @@ const MapContainer = () => {
       const id = hoveredVoxelIdRef.current;
       if (e.ctrlKey && e.key === "c" && id) {
         if (!window.getSelection()?.toString()) {
-          navigator.clipboard.writeText(id);
-          console.log("Copied to clipboard:", id);
+          navigator.clipboard
+            .writeText(id)
+            .then(() => {
+              console.log("Copied to clipboard:", id);
+            })
+            .catch((err) => {
+              console.error("Failed to copy to clipboard:", err);
+            });
         }
       }
     };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,16 +31,14 @@ const MapContainer = () => {
     const handleKeyDown = (e: KeyboardEvent) => {
       const id = hoveredVoxelIdRef.current;
       if (e.ctrlKey && e.key === "c" && id) {
-        if (!window.getSelection()?.toString()) {
-          navigator.clipboard
-            .writeText(id)
-            .then(() => {
-              console.log("Copied to clipboard:", id);
-            })
-            .catch((err) => {
-              console.error("Failed to copy to clipboard:", err);
-            });
-        }
+        navigator.clipboard
+          .writeText(id)
+          .then(() => {
+            console.log("Copied to clipboard:", id);
+          })
+          .catch((err) => {
+            console.error("Failed to copy to clipboard:", err);
+          });
       }
     };
     window.addEventListener("keydown", handleKeyDown);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import type { LayersList, MapViewState } from "@deck.gl/core";
 import DeckGL from "@deck.gl/react";
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { Map as MapGL } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { DrawModeToolbar } from "./components/draw-mode-manager";
@@ -23,6 +23,23 @@ const MapContainer = () => {
     (state) => state.spatialIdGroups,
   );
   const rangeMode = useSpatialIdGroupStore((state) => state.rangeMode);
+
+  // useRefを使用して再描画を防ぐ
+  const hoveredVoxelIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const id = hoveredVoxelIdRef.current;
+      if (e.ctrlKey && e.key === "c" && id) {
+        if (!window.getSelection()?.toString()) {
+          navigator.clipboard.writeText(id);
+          console.log("Copied to clipboard:", id);
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const baseLayers = useMemo(() => {
     const pointsList = Array.from(pointsMap.values());
@@ -49,6 +66,12 @@ const MapContainer = () => {
       controller={true}
       style={{ width: "100vw", height: "100vh" }}
       layers={layers}
+      onHover={({ object }) => {
+        hoveredVoxelIdRef.current = object?.voxelId || null;
+      }}
+      getTooltip={({ object }) =>
+        object?.voxelId ? `${object.voxelId}` : null
+      }
     >
       <MapGL mapStyle="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json" />
     </DeckGL>

--- a/src/utils/layerGenerator.ts
+++ b/src/utils/layerGenerator.ts
@@ -62,7 +62,9 @@ export function generateVoxelLayer(
   return new SolidPolygonLayer<VoxelGeometry>({
     id: `voxel-layer-${id}`,
     data: geometries,
-    pickable: false,
+    pickable: true,
+    autoHighlight: true,
+    highlightColor: [255, 255, 255, 150],
     extruded: true,
     wireframe: true,
     getPolygon: (d) => d.points,


### PR DESCRIPTION
# 実装内容

- 地図上に描画されている時空間IDに対してカーソルを当てたときにIDを文字列として表示する
- カーソルを当てているときに`Ctrl+C`を押すとIDが文字列としてクリップボードにコピーされる