### PR TITLE
時空間IDのJSONファイル読み込み対応

### DIFF
--- a/src/components/feature-manager/FeatureManager.tsx
+++ b/src/components/feature-manager/FeatureManager.tsx
@@ -1,7 +1,13 @@
-import { IconCube, IconLine, IconPoint } from "@tabler/icons-react";
+import {
+  IconCube,
+  IconFileDescription,
+  IconLine,
+  IconPoint,
+} from "@tabler/icons-react";
 import FeatureButton from "./FeatureButton";
 import toolbarStyles from "./FeatureToolbar.module.scss";
 import { useFeatureManagerStore } from "./featureManagerStore";
+import { JsonPanel } from "./json";
 import { LinePanel } from "./line";
 import { PointPanel } from "./point";
 import { SpatialIdPanel } from "./spatial-id";
@@ -23,6 +29,12 @@ export default function FeatureManager() {
           onClick={() => toggleMode("spatial")}
         />
         <FeatureButton
+          name={"JSON"}
+          icon={IconFileDescription}
+          isActive={activeMode === "json"}
+          onClick={() => toggleMode("json")}
+        />
+        <FeatureButton
           name={"点"}
           icon={IconPoint}
           isActive={activeMode === "point"}
@@ -36,6 +48,7 @@ export default function FeatureManager() {
         />
       </div>
       {activeMode === "spatial" && <SpatialIdPanel />}
+      {activeMode === "json" && <JsonPanel />}
       {activeMode === "point" && <PointPanel />}
       {activeMode === "line" && <LinePanel />}
     </div>

--- a/src/components/feature-manager/common-ui/ColorPanel.tsx
+++ b/src/components/feature-manager/common-ui/ColorPanel.tsx
@@ -18,6 +18,7 @@ export interface ColorPanelProps {
   onClose: () => void;
   triggerRect: DOMRect | null;
   ignoreRef?: React.RefObject<HTMLElement | null>;
+  opacityOnly?: boolean;
 }
 
 type AlphaPointerProps = {
@@ -107,6 +108,7 @@ export default function ColorPanel({
   onClose,
   triggerRect,
   ignoreRef,
+  opacityOnly = false,
 }: ColorPanelProps) {
   const [internalColor, setInternalColor] = useState<RGBColor>({
     r: color.r,
@@ -175,16 +177,18 @@ export default function ColorPanel({
       onClick={(e) => e.stopPropagation()}
       onKeyDown={(e) => e.stopPropagation()}
     >
-      <div className={styles.circlePickerWrapper}>
-        <CirclePicker
-          color={internalColor}
-          onChange={handleChange}
-          width="100%"
-          circleSize={22}
-          circleSpacing={11}
-          colors={preset_colors}
-        />
-      </div>
+      {!opacityOnly && (
+        <div className={styles.circlePickerWrapper}>
+          <CirclePicker
+            color={internalColor}
+            onChange={handleChange}
+            width="100%"
+            circleSize={22}
+            circleSpacing={11}
+            colors={preset_colors}
+          />
+        </div>
+      )}
       <AlphaSection color={internalColor} onChange={handleChange} />
     </div>,
     document.body,

--- a/src/components/feature-manager/common-ui/FeatureItemBox.module.scss
+++ b/src/components/feature-manager/common-ui/FeatureItemBox.module.scss
@@ -7,10 +7,31 @@
   width: 100%;
 }
 
+.itemBoxHorizontal {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid #f3f4f6;
+  width: 100%;
+}
+
 .actionGroup {
   display: flex;
   flex-direction: column;
   height: 5rem;
   justify-content: space-between;
   align-items: center;
+}
+
+.actionGroupHorizontal {
+  display: flex;
+  flex-direction: row;
+  height: auto;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  align-items: center;
+  align-self: flex-end;
 }

--- a/src/components/feature-manager/common-ui/FeatureItemBox.tsx
+++ b/src/components/feature-manager/common-ui/FeatureItemBox.tsx
@@ -4,6 +4,7 @@ import styles from "./FeatureItemBox.module.scss";
 type FeatureItemBoxProps = {
   children: ReactNode;
   actions: ReactNode;
+  horizontal?: boolean;
 };
 
 /**
@@ -13,11 +14,18 @@ type FeatureItemBoxProps = {
 export default function FeatureItemBox({
   children,
   actions,
+  horizontal = false,
 }: FeatureItemBoxProps) {
   return (
-    <div className={styles.itemBox}>
+    <div className={horizontal ? styles.itemBoxHorizontal : styles.itemBox}>
       {children}
-      <div className={styles.actionGroup}>{actions}</div>
+      <div
+        className={
+          horizontal ? styles.actionGroupHorizontal : styles.actionGroup
+        }
+      >
+        {actions}
+      </div>
     </div>
   );
 }

--- a/src/components/feature-manager/featureManagerStore.ts
+++ b/src/components/feature-manager/featureManagerStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-export type ActiveMode = "spatial" | "point" | "line" | null;
+export type ActiveMode = "spatial" | "json" | "point" | "line" | null;
 
 interface FeatureManagerState {
   activeMode: ActiveMode;

--- a/src/components/feature-manager/json/JsonBox.module.scss
+++ b/src/components/feature-manager/json/JsonBox.module.scss
@@ -1,0 +1,30 @@
+.dataSection {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.metaRow {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+}
+
+.metaLabel {
+  color: #64748b;
+  font-weight: 500;
+}
+
+.metaValue {
+  font-weight: 500;
+  color: #334155;
+  text-align: right;
+  word-break: break-all;
+}
+
+.error {
+  color: #dc2626;
+  font-size: 12px;
+  margin-top: 8px;
+  padding: 0 16px;
+}

--- a/src/components/feature-manager/json/JsonBox.tsx
+++ b/src/components/feature-manager/json/JsonBox.tsx
@@ -1,0 +1,107 @@
+import { IconTarget, IconTrash } from "@tabler/icons-react";
+import type React from "react";
+import { useCallback, useRef, useState } from "react";
+import type { JsonLayerData } from "../../../stores/jsonLayerStore";
+import { useMapStore } from "../../../stores/mapStore";
+import { useTimeStore } from "../../../stores/timeStore";
+import { calculateVoxelFocus } from "../../../utils/focusHelper";
+import { jsonToGeometry } from "../../../utils/parser/jsonToGeometry";
+import ColorButton from "../common-ui/ColorButton";
+import ColorPanel from "../common-ui/ColorPanel";
+import FeatureItemBox from "../common-ui/FeatureItemBox";
+import IconButton from "../common-ui/IconButton";
+import styles from "./JsonBox.module.scss";
+
+type JsonBoxProps = {
+  data: JsonLayerData;
+  opacity: number;
+  onOpacityChange: (opacity: number) => void;
+  onDelete: () => void;
+};
+
+export default function JsonBox({
+  data,
+  opacity,
+  onOpacityChange,
+  onDelete,
+}: JsonBoxProps) {
+  const colorButtonRef = useRef<HTMLButtonElement>(null);
+  const [triggerRect, setTriggerRect] = useState<DOMRect | null>(null);
+
+  const flyTo = useMapStore((state) => state.flyTo);
+  const setCurrentTime = useTimeStore((state) => state.setCurrentTime);
+
+  const handleFocusClick = () => {
+    const geometries = jsonToGeometry(data, true);
+    if (geometries.length === 0) return;
+    const target = calculateVoxelFocus(geometries);
+    flyTo(target.longitude, target.latitude, target.zoom);
+    if (target.minStartTime !== null) {
+      setCurrentTime(target.minStartTime);
+    }
+  };
+
+  const handleColorClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (triggerRect) {
+      setTriggerRect(null);
+    } else {
+      setTriggerRect(e.currentTarget.getBoundingClientRect());
+    }
+  };
+
+  const handleColorChange = useCallback(
+    (newColor: { r: number; g: number; b: number; a: number }) => {
+      onOpacityChange(newColor.a);
+    },
+    [onOpacityChange],
+  );
+
+  const handleClosePanel = useCallback(() => {
+    setTriggerRect(null);
+  }, []);
+
+  return (
+    <>
+      <FeatureItemBox
+        horizontal={true}
+        actions={
+          <>
+            <IconButton
+              onClick={onDelete}
+              ariaLabel="JSONデータを削除"
+              variant="danger"
+            >
+              <IconTrash />
+            </IconButton>
+            <IconButton onClick={handleFocusClick} ariaLabel="JSONデータに移動">
+              <IconTarget />
+            </IconButton>
+            <ColorButton
+              ref={colorButtonRef}
+              color={{ r: 100, g: 100, b: 100, a: opacity }}
+              ariaLabel="透明度を変更"
+              onClick={handleColorClick}
+            />
+          </>
+        }
+      >
+        <div className={styles.dataSection}>
+          <div className={styles.metaRow}>
+            <span className={styles.metaValue}>{data.name}</span>
+          </div>
+        </div>
+      </FeatureItemBox>
+
+      {triggerRect && (
+        <ColorPanel
+          color={{ r: 100, g: 100, b: 100, a: opacity }}
+          onChange={handleColorChange}
+          onClose={handleClosePanel}
+          triggerRect={triggerRect}
+          ignoreRef={colorButtonRef}
+          opacityOnly={true}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/feature-manager/json/JsonPanel.tsx
+++ b/src/components/feature-manager/json/JsonPanel.tsx
@@ -1,0 +1,78 @@
+import type React from "react";
+import { useRef, useState } from "react";
+import { useJsonLayerStore } from "../../../stores/jsonLayerStore";
+import { jsonToSpatialIds } from "../../../utils/parser/jsonToSpatialIds";
+import FooterAddButton from "../common-ui/FooterAddButton";
+import CommonPanel from "../common-ui/Panel";
+import JsonBox from "./JsonBox";
+
+export default function JsonPanel() {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const { data, opacity, setData, setOpacity, clearData } = useJsonLayerStore();
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const jsonString = event.target?.result as string;
+        const parsedData = jsonToSpatialIds(jsonString);
+        setData(parsedData);
+        setError(null);
+      } catch (err: unknown) {
+        const errorMessage = err instanceof Error ? err.message : String(err);
+        setError(errorMessage || "JSONのパースに失敗しました。");
+      }
+      if (fileInputRef.current) fileInputRef.current.value = "";
+    };
+    reader.onerror = () => {
+      setError("ファイルの読み込みに失敗しました。");
+    };
+    reader.readAsText(file);
+  };
+
+  const handleAddClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  return (
+    <CommonPanel
+      footerButton={
+        <FooterAddButton onClick={handleAddClick} ariaLabel="JSONを追加" />
+      }
+    >
+      <input
+        type="file"
+        accept=".json"
+        ref={fileInputRef}
+        onChange={handleFileUpload}
+        style={{ display: "none" }}
+      />
+      {error && (
+        <div
+          style={{
+            color: "#dc2626",
+            fontSize: "12px",
+            marginTop: "8px",
+            padding: "0 16px",
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {data && (
+        <JsonBox
+          data={data}
+          opacity={opacity}
+          onOpacityChange={setOpacity}
+          onDelete={clearData}
+        />
+      )}
+    </CommonPanel>
+  );
+}

--- a/src/components/feature-manager/json/index.ts
+++ b/src/components/feature-manager/json/index.ts
@@ -1,0 +1,1 @@
+export { default as JsonPanel } from "./JsonPanel";

--- a/src/components/feature-manager/spatial-id-json/DefaultButton.tsx
+++ b/src/components/feature-manager/spatial-id-json/DefaultButton.tsx
@@ -1,3 +1,0 @@
-export default function DefaultButton() {
-  DefaultButton;
-}

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -3,15 +3,18 @@ import DeckGL from "@deck.gl/react";
 import { useEffect, useMemo, useRef } from "react";
 import { Map as MapGL } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
+import { useJsonLayerStore } from "../../stores/jsonLayerStore";
 import { useLineStore } from "../../stores/lineStores";
 import { useMapStore } from "../../stores/mapStore";
 import { usePointStore } from "../../stores/pointStores";
 import { useSpatialIdGroupStore } from "../../stores/spatialIdGroupStores";
 import { useTimeStore } from "../../stores/timeStore";
 import {
+  generateJsonVoxelLayer,
   generateMapLayers,
   generateVoxelLayer,
 } from "../../utils/layerGenerator";
+import { jsonToGeometry } from "../../utils/parser/jsonToGeometry";
 import { spatialIdGroupToGeometries } from "../../utils/parser/voxelToGeometry";
 
 export default function MapContainer() {
@@ -25,6 +28,12 @@ export default function MapContainer() {
   );
   const rangeMode = useSpatialIdGroupStore((state) => state.rangeMode);
   const currentTime = useTimeStore((state) => state.currentTime);
+
+  const {
+    data: jsonData,
+    visible: jsonVisible,
+    opacity: jsonOpacity,
+  } = useJsonLayerStore();
 
   // useRefを使用して再描画を防ぐ
   const hoveredVoxelIdRef = useRef<string | null>(null);
@@ -73,9 +82,31 @@ export default function MapContainer() {
     });
   }, [allGeometriesMap, currentTime]);
 
+  const jsonGeometries = useMemo(() => {
+    if (!jsonData || !jsonVisible) return [];
+    return jsonToGeometry(jsonData, rangeMode);
+  }, [jsonData, jsonVisible, rangeMode]);
+
+  const jsonLayer = useMemo(() => {
+    if (!jsonData || !jsonVisible || jsonGeometries.length === 0) return null;
+    const filteredJsonGeometries = jsonGeometries.filter((geom) => {
+      if (geom.startTime === null || geom.endTime === null) return true;
+      return geom.startTime <= currentTime && currentTime <= geom.endTime;
+    });
+    return generateJsonVoxelLayer(
+      "json-layer",
+      filteredJsonGeometries,
+      jsonOpacity,
+    );
+  }, [jsonData, jsonVisible, jsonGeometries, currentTime, jsonOpacity]);
+
   const layers: LayersList = useMemo(() => {
-    return [...baseLayers, ...voxelLayers];
-  }, [baseLayers, voxelLayers]);
+    const list = [...baseLayers, ...voxelLayers];
+    if (jsonLayer) {
+      list.push(jsonLayer);
+    }
+    return list;
+  }, [baseLayers, voxelLayers, jsonLayer]);
 
   return (
     <DeckGL
@@ -87,9 +118,13 @@ export default function MapContainer() {
       onHover={({ object }) => {
         hoveredVoxelIdRef.current = object?.voxelId || null;
       }}
-      getTooltip={({ object }) =>
-        object?.voxelId ? `${object.voxelId}` : null
-      }
+      getTooltip={({ object }) => {
+        if (!object?.voxelId) return null;
+        if (object.value !== undefined) {
+          return `${object.voxelId} | ${object.value}`;
+        }
+        return `${object.voxelId}`;
+      }}
     >
       <MapGL mapStyle="https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json" />
     </DeckGL>

--- a/src/stores/jsonLayerStore.ts
+++ b/src/stores/jsonLayerStore.ts
@@ -1,0 +1,41 @@
+import { create } from "zustand";
+import type { RGBAColor } from "../types/geometry/color";
+import type { SpatialId } from "../types/geometry/spatioTemporalId";
+
+export interface JsonSpatialId extends SpatialId {
+  ref: number;
+  color?: RGBAColor;
+  value?: number;
+}
+
+export interface JsonMetaData {
+  kasaneSchemaVersion: string;
+  description?: string;
+}
+
+export interface JsonLayerData {
+  meta?: JsonMetaData;
+  name: string;
+  values: number[];
+  ids: JsonSpatialId[];
+}
+
+interface JsonLayerState {
+  data: JsonLayerData | null;
+  visible: boolean;
+  opacity: number;
+  setData: (data: JsonLayerData | null) => void;
+  setVisible: (visible: boolean) => void;
+  setOpacity: (opacity: number) => void;
+  clearData: () => void;
+}
+
+export const useJsonLayerStore = create<JsonLayerState>((set) => ({
+  data: null,
+  visible: true,
+  opacity: 255,
+  setData: (data) => set({ data }),
+  setVisible: (visible) => set({ visible }),
+  setOpacity: (opacity) => set({ opacity }),
+  clearData: () => set({ data: null }),
+}));

--- a/src/stores/jsonLayerStore.ts
+++ b/src/stores/jsonLayerStore.ts
@@ -4,8 +4,8 @@ import type { SpatialId } from "../types/geometry/spatioTemporalId";
 
 export interface JsonSpatialId extends SpatialId {
   ref: number;
-  color?: RGBAColor;
-  value?: number;
+  color: RGBAColor;
+  value: number;
 }
 
 export interface JsonMetaData {

--- a/src/types/geometry/spatioTemporalId/voxelGeometry.ts
+++ b/src/types/geometry/spatioTemporalId/voxelGeometry.ts
@@ -8,4 +8,5 @@ export interface VoxelGeometry {
   color: RGBAColor;
   startTime: number | null;
   endTime: number | null;
+  value?: number;
 }

--- a/src/types/json/jsonSchema.ts
+++ b/src/types/json/jsonSchema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+/**
+ * JSON用のIDスキーマ
+ */
+export const JsonIdSchema = z.object({
+  z: z.number().int(),
+  f: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  x: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  y: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  i: z.number().optional(),
+  t: z.union([z.number(), z.tuple([z.number(), z.number()])]).optional(),
+  ref: z.number().int(),
+});
+
+/**
+ * JSONファイルのスキーマ
+ */
+export const JsonFileSchema = z.object({
+  meta: z
+    .object({
+      kasaneSchemaVersion: z.string(),
+      description: z.string().optional(),
+    })
+    .optional(),
+  option: z.any().optional(),
+  data: z.array(
+    z.object({
+      name: z.string(),
+      value: z.array(z.number()),
+      ids: z.array(JsonIdSchema),
+    }),
+  ),
+});
+
+export type JsonIdType = z.infer<typeof JsonIdSchema>;
+export type JsonFileType = z.infer<typeof JsonFileSchema>;

--- a/src/utils/color/heatmap.ts
+++ b/src/utils/color/heatmap.ts
@@ -1,0 +1,77 @@
+import type { RGBAColor } from "../../types/geometry/color";
+
+type ColorConverter = (value: number) => RGBAColor;
+
+/**
+ * valueに色を割り当てる関数
+ */
+export function createHeatmapColorScale(values: number[]): ColorConverter {
+  // 空データの場合は青を返す
+  if (values.length === 0) {
+    function fallbackBlue(_value: number): RGBAColor {
+      return { r: 0, g: 0, b: 255, a: 255 };
+    }
+    return fallbackBlue;
+  }
+
+  // valueの最小値と最大値を探す
+  let min = values[0];
+  let max = values[0];
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+
+  // valueの値がすべて同じ場合赤を返す
+  if (min === max) {
+    function fallbackRed(_value: number): RGBAColor {
+      return { r: 255, g: 0, b: 0, a: 255 };
+    }
+    return fallbackRed;
+  }
+
+  // valueに色を割り当てる関数
+  function convertValueToColor(value: number): RGBAColor {
+    const ratio = Math.max(0, Math.min(1, (value - min) / (max - min)));
+
+    // HSLで色計算
+    const h = (1 - ratio) * 240;
+    const s = 1.0;
+    const l = 0.5;
+
+    const c = (1 - Math.abs(2 * l - 1)) * s;
+    const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+    const m = l - c / 2;
+
+    let r1 = 0;
+    let g1 = 0;
+    let b1 = 0;
+
+    if (h >= 0 && h < 60) {
+      r1 = c;
+      g1 = x;
+      b1 = 0;
+    } else if (h >= 60 && h < 120) {
+      r1 = x;
+      g1 = c;
+      b1 = 0;
+    } else if (h >= 120 && h < 180) {
+      r1 = 0;
+      g1 = c;
+      b1 = x;
+    } else if (h >= 180 && h <= 240) {
+      r1 = 0;
+      g1 = x;
+      b1 = c;
+    }
+
+    return {
+      r: Math.round((r1 + m) * 255),
+      g: Math.round((g1 + m) * 255),
+      b: Math.round((b1 + m) * 255),
+      a: 255,
+    };
+  }
+
+  return convertValueToColor;
+}

--- a/src/utils/color/heatmap.ts
+++ b/src/utils/color/heatmap.ts
@@ -3,7 +3,7 @@ import type { RGBAColor } from "../../types/geometry/color";
 type ColorConverter = (value: number) => RGBAColor;
 
 /**
- * valueに色を割り当てる関数
+ * valueに色を割り当てる関数の作成用関数
  */
 export function createHeatmapColorScale(values: number[]): ColorConverter {
   // 空データの場合は青を返す

--- a/src/utils/layerGenerator.ts
+++ b/src/utils/layerGenerator.ts
@@ -77,6 +77,32 @@ export function generateVoxelLayer(
   });
 }
 
+export function generateJsonVoxelLayer(
+  id: string,
+  geometries: VoxelGeometry[],
+  opacity: number,
+): SolidPolygonLayer<VoxelGeometry> {
+  return new SolidPolygonLayer<VoxelGeometry>({
+    id: `json-voxel-layer-${id}`,
+    data: geometries,
+    pickable: true,
+    autoHighlight: true,
+    highlightColor: [255, 255, 255, 150],
+    extruded: true,
+    wireframe: true,
+    getPolygon: (d) => d.points,
+    getElevation: (d) => d.elevation,
+    getFillColor: (d) => {
+      const c = d.color ?? { r: 100, g: 100, b: 100, a: 255 };
+      return [c.r, c.g, c.b, opacity];
+    },
+    getLineColor: [0, 0, 0, 255],
+    updateTriggers: {
+      getFillColor: [opacity],
+    },
+  });
+}
+
 export function generateMapLayers(points: Point[], lines: Line[]): LayersList {
   return [generatePointLayer(points), generateLineLayer(lines)];
 }

--- a/src/utils/parser/jsonToGeometry.ts
+++ b/src/utils/parser/jsonToGeometry.ts
@@ -1,0 +1,31 @@
+import type { JsonLayerData } from "../../stores/jsonLayerStore";
+import type { VoxelGeometry } from "../../types/geometry/spatioTemporalId/voxelGeometry";
+import { spatialIdToVoxels } from "./spatialIdToVoxels";
+import { voxelToGeometry } from "./voxelToGeometry";
+
+//JsonLayerDataからVoxelGeometryに変換
+
+export function jsonToGeometry(
+  jsonLayer: JsonLayerData,
+  rangeMode = true,
+): VoxelGeometry[] {
+  const result: VoxelGeometry[] = [];
+
+  for (const jsonId of jsonLayer.ids) {
+    // SpatialIdとしてvoxel生成
+    const voxels = spatialIdToVoxels(jsonId, rangeMode);
+
+    const color = jsonId.color;
+
+    const geometries = voxels.map((voxel) => {
+      const geom = voxelToGeometry(voxel, color);
+      // ValueをGeometry に追加
+      geom.value = jsonId.value;
+      return geom;
+    });
+
+    result.push(...geometries);
+  }
+
+  return result;
+}

--- a/src/utils/parser/jsonToSpatialIds.ts
+++ b/src/utils/parser/jsonToSpatialIds.ts
@@ -1,0 +1,60 @@
+import type { JsonLayerData, JsonSpatialId } from "../../stores/jsonLayerStore";
+import { JsonFileSchema } from "../../types/json/jsonSchema";
+import { createHeatmapColorScale } from "../color/heatmap";
+
+//アップロードされたJSONファイルをJsonLayerData型に変換
+
+export function jsonToSpatialIds(jsonString: string): JsonLayerData {
+  const parsed = JSON.parse(jsonString);
+  const validated = JsonFileSchema.parse(parsed);
+
+  if (validated.data.length === 0) {
+    throw new Error("JSONの data 配列が空です。");
+  }
+
+  // 1つ目のデータのみ使用
+  const firstData = validated.data[0];
+  const colorScale = createHeatmapColorScale(firstData.value);
+
+  const jsonSpatialIds: JsonSpatialId[] = firstData.ids.map((idObj) => {
+    const f = idObj.f ?? 0;
+    const x = idObj.x ?? 0;
+    const y = idObj.y ?? 0;
+
+    let temporalId:
+      | {
+          i: number;
+          t: number | [number, number];
+        }
+      | undefined;
+    if (idObj.i !== undefined && idObj.t !== undefined) {
+      temporalId = { i: idObj.i, t: idObj.t };
+    }
+
+    // SpatialIdの形式に変換
+    const spatialIdRaw = {
+      z: idObj.z,
+      f,
+      x,
+      y,
+      temporalId,
+    };
+
+    const refValue = firstData.value[idObj.ref];
+    const color = colorScale(refValue);
+
+    return {
+      ...spatialIdRaw,
+      ref: idObj.ref,
+      value: refValue,
+      color,
+    };
+  });
+
+  return {
+    meta: validated.meta,
+    name: firstData.name,
+    values: firstData.value,
+    ids: jsonSpatialIds,
+  };
+}

--- a/src/utils/parser/jsonToSpatialIds.ts
+++ b/src/utils/parser/jsonToSpatialIds.ts
@@ -40,6 +40,11 @@ export function jsonToSpatialIds(jsonString: string): JsonLayerData {
       temporalId,
     };
 
+    if (idObj.ref < 0 || idObj.ref >= firstData.value.length) {
+      throw new Error(
+        `参照ID (ref: ${idObj.ref}) が values 配列の範囲外です。`,
+      );
+    }
     const refValue = firstData.value[idObj.ref];
     const color = colorScale(refValue);
 


### PR DESCRIPTION
## 実施内容
時空間IDのJSONファイル読み込み対応とヒートマップ用のカラーマッピング関数の実装

- jsonToSpatialIds.ts
   - 生テキストを1度だけパースし、省略された座標の補完と色の事前計算を行う。JsonLayerDataとしてStoreにキャッシュ
- jsonToGeometry.ts
   - Storeのデータから、VoxelGeometryへ変換
- heatmap.ts
  - HSLカラーモデルを用いて青から赤のグラデーションを算出