### PR TITLE
deckglの設定調整

### DIFF
--- a/src/components/draw-mode-manager/DrawModeToolbar.tsx
+++ b/src/components/draw-mode-manager/DrawModeToolbar.tsx
@@ -1,6 +1,7 @@
 import {
   IconBorderOuter,
   IconMap,
+  IconPointer,
   IconRefresh,
   IconTableMinus,
 } from "@tabler/icons-react";
@@ -17,6 +18,8 @@ export default function DrawModeToolbar() {
   );
   const showBorder = useSpatialIdGroupStore((state) => state.showBorder);
   const toggleBorder = useSpatialIdGroupStore((state) => state.toggleBorder);
+  const pickable = useSpatialIdGroupStore((state) => state.pickable);
+  const togglePicking = useSpatialIdGroupStore((state) => state.togglePicking);
 
   return (
     <div className={styles.rightControls}>
@@ -29,6 +32,11 @@ export default function DrawModeToolbar() {
         icon={IconBorderOuter}
         isActive={showBorder}
         onClick={toggleBorder}
+      />
+      <DrawModeButton
+        icon={IconPointer}
+        isActive={pickable}
+        onClick={togglePicking}
       />
       <DrawModeButton icon={IconMap} isActive={false} />
       <DrawModeButton icon={IconTableMinus} isActive={false} />

--- a/src/components/map/MapContainer.tsx
+++ b/src/components/map/MapContainer.tsx
@@ -28,6 +28,7 @@ export default function MapContainer() {
   );
   const rangeMode = useSpatialIdGroupStore((state) => state.rangeMode);
   const showBorder = useSpatialIdGroupStore((state) => state.showBorder);
+  const pickable = useSpatialIdGroupStore((state) => state.pickable);
   const currentTime = useTimeStore((state) => state.currentTime);
 
   const {
@@ -84,9 +85,10 @@ export default function MapContainer() {
         filteredGeometries,
         group.color,
         showBorder,
+        pickable,
       );
     });
-  }, [allGeometriesMap, currentTime, showBorder]);
+  }, [allGeometriesMap, currentTime, showBorder, pickable]);
 
   const jsonGeometries = useMemo(() => {
     if (!jsonData || !jsonVisible) return [];
@@ -104,6 +106,7 @@ export default function MapContainer() {
       filteredJsonGeometries,
       jsonOpacity,
       showBorder,
+      pickable,
     );
   }, [
     jsonData,
@@ -112,6 +115,7 @@ export default function MapContainer() {
     currentTime,
     jsonOpacity,
     showBorder,
+    pickable,
   ]);
 
   const layers: LayersList = useMemo(() => {
@@ -127,6 +131,8 @@ export default function MapContainer() {
       viewState={viewState}
       onViewStateChange={(e) => setViewState(e.viewState as MapViewState)}
       controller={true}
+      // 高DPI画面でも論理ピクセル基準で描画し、描画負荷を抑える
+      useDevicePixels={false}
       style={{ width: "100vw", height: "100vh" }}
       layers={layers}
       onHover={({ object }) => {

--- a/src/stores/spatialIdGroupStores.ts
+++ b/src/stores/spatialIdGroupStores.ts
@@ -14,6 +14,7 @@ interface SpatialIdGroupState {
   spatialIdGroups: Map<string, SpatialIdGroup>;
   rangeMode: boolean;
   showBorder: boolean;
+  pickable: boolean;
 }
 
 interface SpatialIdGroupAction {
@@ -27,6 +28,7 @@ interface SpatialIdGroupAction {
   ) => ReturnType<typeof SpatialIdGroupPartialSchema.safeParse>;
   toggleRangeMode: () => void;
   toggleBorder: () => void;
+  togglePicking: () => void;
 }
 
 /**
@@ -41,6 +43,7 @@ export const useSpatialIdGroupStore = create<
       spatialIdGroups: new Map(),
       rangeMode: true,
       showBorder: false,
+      pickable: true,
 
       /**
        * 空間IDグループを追加する
@@ -123,6 +126,19 @@ export const useSpatialIdGroupStore = create<
           },
           false,
           "toggleBorder",
+        ),
+
+      /**
+       * ボクセルのpicking（ホバー判定・ツールチップ等）をトグルする
+       * 大量描画時にOFFにすると軽量化できる
+       */
+      togglePicking: () =>
+        set(
+          (state) => {
+            state.pickable = !state.pickable;
+          },
+          false,
+          "togglePicking",
         ),
     })),
   ),

--- a/src/utils/layerGenerator.ts
+++ b/src/utils/layerGenerator.ts
@@ -59,11 +59,12 @@ export function generateVoxelLayer(
   geometries: VoxelGeometry[],
   color: RGBAColor,
   showBorder = true,
+  pickable = true,
 ): SolidPolygonLayer<VoxelGeometry> {
   return new SolidPolygonLayer<VoxelGeometry>({
     id: `voxel-layer-${id}`,
     data: geometries,
-    pickable: true,
+    pickable,
     autoHighlight: true,
     highlightColor: [255, 255, 255, 150],
     extruded: true,
@@ -83,11 +84,12 @@ export function generateJsonVoxelLayer(
   geometries: VoxelGeometry[],
   opacity: number,
   showBorder = true,
+  pickable = true,
 ): SolidPolygonLayer<VoxelGeometry> {
   return new SolidPolygonLayer<VoxelGeometry>({
     id: `json-voxel-layer-${id}`,
     data: geometries,
-    pickable: true,
+    pickable,
     autoHighlight: true,
     highlightColor: [255, 255, 255, 150],
     extruded: true,

--- a/src/utils/layerGenerator.ts
+++ b/src/utils/layerGenerator.ts
@@ -68,6 +68,8 @@ export function generateVoxelLayer(
     autoHighlight: true,
     highlightColor: [255, 255, 255, 150],
     extruded: true,
+    // ライティング計算を無効化して描画を軽量化
+    material: false,
     wireframe: showBorder,
     getPolygon: (d) => d.points,
     getElevation: (d) => d.elevation,
@@ -93,6 +95,8 @@ export function generateJsonVoxelLayer(
     autoHighlight: true,
     highlightColor: [255, 255, 255, 150],
     extruded: true,
+    // ライティング計算を無効化して描画を軽量化
+    material: false,
     wireframe: showBorder,
     getPolygon: (d) => d.points,
     getElevation: (d) => d.elevation,

--- a/src/utils/layerGenerator.ts
+++ b/src/utils/layerGenerator.ts
@@ -70,6 +70,8 @@ export function generateVoxelLayer(
     extruded: true,
     // ライティング計算を無効化して描画を軽量化
     material: false,
+    // 裏面の描画を省いて軽量化（面の向きに依存）
+    parameters: { cullMode: "back" },
     wireframe: showBorder,
     getPolygon: (d) => d.points,
     getElevation: (d) => d.elevation,
@@ -97,6 +99,8 @@ export function generateJsonVoxelLayer(
     extruded: true,
     // ライティング計算を無効化して描画を軽量化
     material: false,
+    // 裏面の描画を省いて軽量化（面の向きに依存）
+    parameters: { cullMode: "back" },
     wireframe: showBorder,
     getPolygon: (d) => d.points,
     getElevation: (d) => d.elevation,


### PR DESCRIPTION
アルゴリズムを用いず、deckglの設定調節のみで描画を軽量化した。

# Pickingの切り替えによる軽量化
空間IDに触れたときにIDの文字列を表示する処理は大量描画の際には重い。PickingをONにすることでdeckglの描画全体が重くなる。そのため、`DrawModeToolbar`にボタンを追加し、OFFにできるようにした。

デフォルトではONであるが、ユーザーが軽量描画に切り替えたい時だけはOFFにすることができる。

# ライティングの無効化
`material: false`を適応し、陰影をなくした。

# `parameters: { cullMode: "back" }`を設定
カメラから見えない描画を省略した。

# `useDevicePixels={false}`を追加
描画をCSSの論理ピクセルに合わせた。