### PR TITLE
`.txt`からの読み込みを実装

### DIFF
--- a/src/components/feature-manager/spatial-id/SpatialIdBox.module.scss
+++ b/src/components/feature-manager/spatial-id/SpatialIdBox.module.scss
@@ -35,3 +35,39 @@
   font-size: 0.75rem;
   color: #ef4444;
 }
+
+.fileRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.reloadButton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid #e2e8f0;
+  background-color: #ffffff;
+  color: #475569;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background-color 0.2s ease;
+
+  &:hover {
+    border-color: #0f766e;
+    color: #0f766e;
+    background-color: #f0fdfa;
+  }
+}
+
+.fileName {
+  font-size: 0.75rem;
+  color: #475569;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 12rem;
+}

--- a/src/components/feature-manager/spatial-id/SpatialIdBox.tsx
+++ b/src/components/feature-manager/spatial-id/SpatialIdBox.tsx
@@ -1,7 +1,8 @@
-import { IconTarget, IconTrash } from "@tabler/icons-react";
+import { IconRefresh, IconTarget, IconTrash } from "@tabler/icons-react";
 import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useMapStore } from "../../../stores/mapStore";
+import { getGroupFile } from "../../../stores/spatialIdGroupFiles";
 import { useSpatialIdGroupStore } from "../../../stores/spatialIdGroupStores";
 import { useTimeStore } from "../../../stores/timeStore";
 import type { SpatialId } from "../../../types/geometry/spatioTemporalId";
@@ -48,10 +49,19 @@ export default function SpatialIdBox({
   const buttonRef = useRef<HTMLButtonElement>(null);
   const isTypingRef = useRef(false);
 
+  // .txtファイル再読み込み用
+  const [fileError, setFileError] = useState<string | null>(null);
+
+  // 元ファイルのハンドルを持つグループは.txt由来。
+  // ファイルで読み込んでいるのか、テキスト直打ちなのかのフラグ
+  const fileHandle = getGroupFile(group.id);
+  const isFileGroup = fileHandle != null;
+
   const flyTo = useMapStore((state) => state.flyTo);
   const setCurrentTime = useTimeStore((state) => state.setCurrentTime);
 
   useEffect(() => {
+    if (isFileGroup) return;
     if (isTypingRef.current) {
       isTypingRef.current = false;
       return;
@@ -59,7 +69,7 @@ export default function SpatialIdBox({
     const joined = group.spatialIds.map(spatialIdToString).join(", ");
     setText(joined);
     setErrorMsg(null);
-  }, [group.spatialIds]);
+  }, [group.spatialIds, isFileGroup]);
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     isTypingRef.current = true;
@@ -79,6 +89,40 @@ export default function SpatialIdBox({
       setErrorMsg(null);
       onUpdate(group.id, { spatialIds: parsed.success });
     }
+  };
+
+  // 保持しているファイルハンドルから同じファイルを再読み込みし、パース結果でグループの空間IDを全置換（全削除＋全挿入）する
+  const handleReloadClick = async () => {
+    const handle = getGroupFile(group.id);
+    if (!handle) {
+      setFileError(
+        "再読み込み元のファイルが見つかりません。再度追加してください。",
+      );
+      return;
+    }
+
+    let content: string;
+    try {
+      const file = await handle.getFile();
+      content = await file.text();
+    } catch {
+      setFileError("ファイルの再読み込みに失敗しました。");
+      return;
+    }
+
+    if (content.trim() === "") {
+      onUpdate(group.id, { spatialIds: [] });
+      setFileError(null);
+      return;
+    }
+
+    const parsed = stringToSpatialIds(content);
+    if (parsed.errors.length > 0) {
+      setFileError(`${parsed.errors[0].content}: ${parsed.errors[0].message}`);
+      return;
+    }
+    setFileError(null);
+    onUpdate(group.id, { spatialIds: parsed.success });
   };
 
   const handleColorClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -139,20 +183,41 @@ export default function SpatialIdBox({
         </>
       }
     >
-      <div className={styles.textareaWrapper}>
-        <textarea
-          id={`spatial-id-input-${group.id}`}
-          className={`${styles.textarea} ${errorMsg ? styles.textareaError : ""}`}
-          value={text}
-          onChange={handleChange}
-          rows={3}
-        />
-        {errorMsg && (
-          <div className={styles.errorMessage} role="alert">
-            {errorMsg}
+      {isFileGroup ? (
+        <div className={styles.textareaWrapper}>
+          <div className={styles.fileRow}>
+            <span className={styles.fileName}>{fileHandle?.name}</span>
+            <button
+              type="button"
+              className={styles.reloadButton}
+              onClick={handleReloadClick}
+              aria-label="txtファイルを再読み込み"
+            >
+              <IconRefresh size={16} />
+            </button>
           </div>
-        )}
-      </div>
+          {fileError && (
+            <div className={styles.errorMessage} role="alert">
+              {fileError}
+            </div>
+          )}
+        </div>
+      ) : (
+        <div className={styles.textareaWrapper}>
+          <textarea
+            id={`spatial-id-input-${group.id}`}
+            className={`${styles.textarea} ${errorMsg ? styles.textareaError : ""}`}
+            value={text}
+            onChange={handleChange}
+            rows={3}
+          />
+          {errorMsg && (
+            <div className={styles.errorMessage} role="alert">
+              {errorMsg}
+            </div>
+          )}
+        </div>
+      )}
       {triggerRect && (
         <ColorPanel
           color={color}

--- a/src/components/feature-manager/spatial-id/SpatialIdPanel.tsx
+++ b/src/components/feature-manager/spatial-id/SpatialIdPanel.tsx
@@ -1,5 +1,16 @@
+import type React from "react";
+import { useRef } from "react";
+import {
+  deleteGroupFile,
+  type FileHandleLike,
+  fileToHandle,
+  isFileSystemAccessSupported,
+  pickTextFile,
+  setGroupFile,
+} from "../../../stores/spatialIdGroupFiles";
 import { useSpatialIdGroupStore } from "../../../stores/spatialIdGroupStores";
 import type { SpatialIdGroup } from "../../../types/geometry/spatioTemporalId/spatialIdGroup";
+import { stringToSpatialIds } from "../../../utils/parser/stringToSpatialIds";
 import FooterAddButton from "../common-ui/FooterAddButton";
 import CommonPanel from "../common-ui/Panel";
 import SpatialIdBox from "./SpatialIdBox";
@@ -18,6 +29,8 @@ export default function SpatialIdPanel() {
     (state) => state.removeSpatialIdGroup,
   );
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
   const groupsList = Array.from(spatialIdGroupsMap.values());
 
   const handleAdd = () => {
@@ -27,18 +40,81 @@ export default function SpatialIdPanel() {
     });
   };
 
+  // ハンドルからファイルを読み込み、新しいグループを作成してハンドルを保持する
+  const addGroupFromHandle = async (handle: FileHandleLike) => {
+    const file = await handle.getFile();
+    const content = await file.text();
+    const parsed = stringToSpatialIds(content);
+
+    // 追加されたグループのIDを特定するため、追加前後のキー差分を取る
+    const before = new Set(
+      useSpatialIdGroupStore.getState().spatialIdGroups.keys(),
+    );
+    const result = addSpatialIdGroup({
+      color: { r: 15, g: 118, b: 110, a: 128 },
+      spatialIds: parsed.success,
+    });
+    if (!result.success) return;
+
+    const after = useSpatialIdGroupStore.getState().spatialIdGroups;
+    for (const key of after.keys()) {
+      if (!before.has(key)) {
+        setGroupFile(key, handle);
+        break;
+      }
+    }
+  };
+
+  const handleAddTxtClick = async () => {
+    // 非対応ブラウザ（Firefox/Safari等）は <input type=file> にフォールバック
+    if (!isFileSystemAccessSupported()) {
+      fileInputRef.current?.click();
+      return;
+    }
+
+    let handle: FileHandleLike | null;
+    try {
+      handle = await pickTextFile();
+    } catch {
+      return;
+    }
+    if (!handle) return;
+
+    await addGroupFromHandle(handle);
+  };
+
+  // フォールバック（<input type=file>）からの追加
+  const handleAddFromInput = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (fileInputRef.current) fileInputRef.current.value = "";
+    if (!file) return;
+
+    await addGroupFromHandle(fileToHandle(file));
+  };
+
   const handleUpdate = (id: string, updates: Partial<SpatialIdGroup>) => {
     editSpatialIdGroup(id, updates);
   };
 
   const handleDelete = (id: string) => {
+    deleteGroupFile(id);
     removeSpatialIdGroup(id);
   };
 
   return (
     <CommonPanel
       footerButton={
-        <FooterAddButton onClick={handleAdd} ariaLabel="IDを追加" />
+        <div style={{ display: "flex", gap: "0.5rem" }}>
+          <FooterAddButton onClick={handleAdd} ariaLabel="IDを追加" />
+          <FooterAddButton onClick={handleAddTxtClick} ariaLabel=".txtを追加" />
+          <input
+            type="file"
+            accept=".txt"
+            ref={fileInputRef}
+            onChange={handleAddFromInput}
+            style={{ display: "none" }}
+          />
+        </div>
       }
     >
       {groupsList.map((group) => (

--- a/src/stores/spatialIdGroupFiles.ts
+++ b/src/stores/spatialIdGroupFiles.ts
@@ -1,0 +1,74 @@
+/**
+ * 空間IDグループに紐づく元ファイルのハンドルを保持するモジュール。
+ *
+ * 再読み込み（ファイル編集後の内容反映）のために、選択時のファイルハンドルを
+ * グループIDごとに保持する。File System Access API の FileSystemFileHandle は
+ * ホストオブジェクトのため、zustand/immer の状態には入れずここで別管理する。
+ */
+export type FileHandleLike = {
+  name: string;
+  getFile: () => Promise<File>;
+};
+
+type ShowOpenFilePicker = (options?: {
+  types?: { description?: string; accept: Record<string, string[]> }[];
+  excludeAcceptAllOption?: boolean;
+  multiple?: boolean;
+}) => Promise<FileHandleLike[]>;
+
+/**
+ * File System Access API（showOpenFilePicker）に対応しているか。
+ * 対応: Chromium系（Brave/Chrome/Edge）。非対応: Firefox/Safari。
+ */
+export function isFileSystemAccessSupported(): boolean {
+  return (
+    typeof (window as unknown as { showOpenFilePicker?: unknown })
+      .showOpenFilePicker === "function"
+  );
+}
+
+/**
+ * <input type="file"> で取得した File を FileHandleLike にラップする。
+ * （非対応ブラウザ向けフォールバック。getFile は同じ File を返すため、
+ *  再読み込みでの編集反映はブラウザの再読み込み挙動に依存する）
+ */
+export function fileToHandle(file: File): FileHandleLike {
+  return {
+    name: file.name,
+    getFile: async () => file,
+  };
+}
+
+const groupFiles = new Map<string, FileHandleLike>();
+
+export function setGroupFile(id: string, handle: FileHandleLike): void {
+  groupFiles.set(id, handle);
+}
+
+export function getGroupFile(id: string): FileHandleLike | undefined {
+  return groupFiles.get(id);
+}
+
+export function deleteGroupFile(id: string): void {
+  groupFiles.delete(id);
+}
+
+/**
+ * .txtファイルを選択し、ファイルハンドルを返す。
+ * File System Access API 非対応ブラウザの場合は null を返す。
+ * ユーザーがキャンセルした場合は例外（AbortError）が投げられる。
+ */
+export async function pickTextFile(): Promise<FileHandleLike | null> {
+  const picker = (
+    window as unknown as { showOpenFilePicker?: ShowOpenFilePicker }
+  ).showOpenFilePicker;
+  if (!picker) return null;
+
+  const [handle] = await picker({
+    types: [
+      { description: "テキストファイル", accept: { "text/plain": [".txt"] } },
+    ],
+    multiple: false,
+  });
+  return handle ?? null;
+}


### PR DESCRIPTION
# 概要
- `.txt`ファイルを選択してカンマ区切りの空間IDを描画できる機能を追加
- ファイルが更新された場合は再読み込みボタンを押すことで更新できる

これらの変更により他プログラムで書き出したテキストファイルをコピーする必要がなくなった。

# スクリーンショット

## ファイル選択前
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/d5cb9294-9a43-44ce-8f6f-8eb7fe904c30" />

## ファイル選択時
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b11feef0-16f4-4d3c-af99-772037de2dae" />
