### PR TITLE
heatmap用に色割/透明度の追加

### DIFF
--- a/src/components/map/KasaneTileLayer.tsx
+++ b/src/components/map/KasaneTileLayer.tsx
@@ -2,13 +2,14 @@ import { TileLayer } from "@deck.gl/geo-layers";
 import { ScatterplotLayer, SolidPolygonLayer } from "@deck.gl/layers";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { searchData } from "../../api/kasane/api";
-import type { RangeId } from "../../api/kasane/types";
+import type { RangeId, SpatialData } from "../../api/kasane/types";
 import { useKasaneStore } from "../../stores/kasaneStore";
 import {
   f_min,
   fxy_max,
 } from "../../types/geometry/spatioTemporalId/spatialId";
 import type { VoxelGeometry } from "../../types/geometry/spatioTemporalId/voxelGeometry";
+import { createHeatmapColorScale } from "../../utils/color/heatmap";
 import {
   type KasaneWorkerInput,
   type KasaneWorkerOutput,
@@ -21,6 +22,9 @@ const createWorker = () =>
   });
 
 const KASANE_COLOR = { r: 220, g: 120, b: 20, a: 160 };
+
+// Kasaneのheatmap用カラースケール (0〜100 の固定範囲)
+const heatmapColorScale = createHeatmapColorScale([0, 100]);
 
 /**
  * 1次元配列(Float64Array)から、VoxelGeometryの配列へ復元する。
@@ -143,6 +147,26 @@ function createPolygonLayer(id: string, data: VoxelGeometry[]) {
     wireframe: false,
     elevationScale: 1,
     pickable: true,
+  });
+}
+
+function mapCellsToWorkerInput(cells: SpatialData[], selectedDb: string) {
+  const isHeatmap = selectedDb === "riskmap" || selectedDb === "heatmap";
+  return cells.map((c) => {
+    let cellColor: { r: number; g: number; b: number; a: number } | undefined;
+    if (isHeatmap) {
+      const val = typeof c.data === "number" ? c.data : Number(c.data);
+      if (!Number.isNaN(val)) {
+        cellColor = heatmapColorScale(val);
+      }
+    }
+    return {
+      z: c.id.z,
+      f: c.id.f,
+      x: c.id.x,
+      y: c.id.y,
+      color: cellColor,
+    };
   });
 }
 
@@ -272,12 +296,7 @@ export function useKasaneTileLayer() {
                 type: "PARSE_VOXELS",
                 jobId,
                 payload: {
-                  cells: cells.map((c) => ({
-                    z: c.id.z,
-                    f: c.id.f,
-                    x: c.id.x,
-                    y: c.id.y,
-                  })),
+                  cells: mapCellsToWorkerInput(cells, selectedDb),
                   color: KASANE_COLOR,
                 },
               };

--- a/src/utils/color/heatmap.ts
+++ b/src/utils/color/heatmap.ts
@@ -65,11 +65,14 @@ export function createHeatmapColorScale(values: number[]): ColorConverter {
       b1 = c;
     }
 
+    // 不透明度はリスクに応じて 50 〜 255まで変化させる
+    const alpha = Math.round(50 + 205 * ratio);
+
     return {
       r: Math.round((r1 + m) * 255),
       g: Math.round((g1 + m) * 255),
       b: Math.round((b1 + m) * 255),
-      a: 255,
+      a: alpha,
     };
   }
 

--- a/src/workers/kasaneWorker.ts
+++ b/src/workers/kasaneWorker.ts
@@ -16,6 +16,7 @@ self.onmessage = (e: MessageEvent<KasaneWorkerInput>) => {
 
     for (let i = 0; i < count; i++) {
       const c = cells[i];
+      const cellColor = c.color ?? color;
       const geom = voxelToGeometry(
         {
           z: c.z,
@@ -26,7 +27,7 @@ self.onmessage = (e: MessageEvent<KasaneWorkerInput>) => {
           yMin: c.y,
           yMax: c.y,
         },
-        color,
+        cellColor,
       );
 
       const o = i * VOXEL_STRIDE;
@@ -39,10 +40,10 @@ self.onmessage = (e: MessageEvent<KasaneWorkerInput>) => {
       }
       buffer[o + 15] = geom.altitude;
       buffer[o + 16] = geom.elevation;
-      buffer[o + 17] = color.r;
-      buffer[o + 18] = color.g;
-      buffer[o + 19] = color.b;
-      buffer[o + 20] = color.a;
+      buffer[o + 17] = cellColor.r;
+      buffer[o + 18] = cellColor.g;
+      buffer[o + 19] = cellColor.b;
+      buffer[o + 20] = cellColor.a;
       buffer[o + 21] = geom.startTime ?? Number.NaN;
       buffer[o + 22] = geom.endTime ?? Number.NaN;
 

--- a/src/workers/kasaneWorkerProtocol.ts
+++ b/src/workers/kasaneWorkerProtocol.ts
@@ -18,7 +18,7 @@ export type KasaneWorkerInput = {
   type: "PARSE_VOXELS";
   jobId: string;
   payload: {
-    cells: { z: number; f: number; x: number; y: number }[];
+    cells: { z: number; f: number; x: number; y: number; color?: RGBAColor }[];
     color: RGBAColor;
   };
 };


### PR DESCRIPTION
## 変更内容
- kasaneからのheatmapデータに対して、色と不透明度の割り振りの追加
<img width="1470" height="835" alt="Screenshot_2026-06-28_at_12 20 18" src="https://github.com/user-attachments/assets/3351bad4-155d-4c1d-865c-34d4d6d8c89c" />
